### PR TITLE
Remove parameters that aren't in the API responses anymore, and are unused

### DIFF
--- a/src/Requests.elm
+++ b/src/Requests.elm
@@ -236,9 +236,6 @@ variableCommonFieldsDecoder =
         |: (field "entity" string)
         |: (maybe (field "label" string))
         |: (field "name" string)
-        |: (field "source_code" string)
-        |: (field "source_file_path" string)
-        |: (field "start_line_number" int)
 
 
 variableDecoder : Decoder Variable

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -323,9 +323,6 @@ type alias VariableCommonFields =
     { entity : EntityKey
     , label : Maybe String
     , name : VariableName
-    , sourceCode : String
-    , sourceFilePath : String
-    , startLineNumber : Int
     }
 
 


### PR DESCRIPTION
Fixes #6 

Having deleted the parameters `source_code`, `source_file_path` and `start_line_number`, the page loads again:

![screenshot_2018-08-02 openfisca demonstrator](https://user-images.githubusercontent.com/167767/43588714-635bc272-966d-11e8-9853-da57727c7478.png)

I'm not sure if anything is missing from the original demonstrator?