### PR TITLE
Use the real API URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,8 +27,7 @@
     <script src="/static/ports.js"></script>
     <script src="/_compile/src/Main.elm"></script>
     <script>
-        var apiBaseUrl = "http://localhost:2000/api";
-        // var apiBaseUrl = "http://localhost:2001/api";
+        const apiBaseUrl = "https://api.openfisca.fr/api";
         var displayDisclaimer = window.localStorage.getItem("display-disclaimer")
         if (displayDisclaimer === null) {
             displayDisclaimer = true

--- a/src/Requests.elm
+++ b/src/Requests.elm
@@ -236,9 +236,6 @@ variableCommonFieldsDecoder =
         |: (field "entity" string)
         |: (maybe (field "label" string))
         |: (field "name" string)
-        |: (field "source_code" string)
-        |: (field "source_file_path" string)
-        |: (field "start_line_number" int)
 
 
 variableDecoder : Decoder Variable

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -323,9 +323,6 @@ type alias VariableCommonFields =
     { entity : EntityKey
     , label : Maybe String
     , name : VariableName
-    , sourceCode : String
-    , sourceFilePath : String
-    , startLineNumber : Int
     }
 
 


### PR DESCRIPTION
This PR is based on the PR #7 (which fixes the API usage).

I believe the `http://localhost:2000` local url was used by the author to host a CORS proxy, or something like that?
This is not available to an external contributor, and not documented, and it seems the real API is responding correctly, so I guess it's not useful anymore?